### PR TITLE
[3.2] libff: fix unused parameter warning

### DIFF
--- a/libff/common/profiling.cpp
+++ b/libff/common/profiling.cpp
@@ -330,7 +330,7 @@ void leave_block(const std::string &msg, const bool indent)
     }
 }
 
-void print_mem(const std::string &s)
+void print_mem([[maybe_unused]] const std::string &s)
 {
 #ifndef NO_PROCPS
     struct proc_t usage;


### PR DESCRIPTION
Fix 
```
/home/lh/work/leap-main/libraries/libfc/libraries/ff/libff/common/profiling.cpp: In function ‘void libff::print_mem(const string&)’:
/home/lh/work/leap-main/libraries/libfc/libraries/ff/libff/common/profiling.cpp:333:35: warning: unused parameter ‘s’ [-Wunused-parameter]
  333 | void print_mem(const std::string &s)
      |                ~~~~~~~~~~~~~~~~~~~^
```